### PR TITLE
Add InfluxDB operator deployment

### DIFF
--- a/microk8s/README.md
+++ b/microk8s/README.md
@@ -13,7 +13,7 @@ manually as microk8s does not provide an OLM add-on.
 - **PostgreSQL** – relational database used by OpenHAB
 - **Keycloak** – identity and access management
 - **HashiCorp Vault** – secrets management
-- Operators for PostgreSQL, Keycloak and Vault (managed by OLM)
+- Operators for PostgreSQL, Keycloak, Vault and InfluxDB (managed by OLM)
 
 Persistent storage is provided via `PersistentVolumeClaim`s. The OpenHAB web
 interface is exposed through an Ingress provided by the microk8s `ingress`

--- a/microk8s/charts/openhab-stack/templates/influxdb-operator.yaml
+++ b/microk8s/charts/openhab-stack/templates/influxdb-operator.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: influxdb-operator
+  labels:
+    app: influxdb-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: influxdb-operator
+  template:
+    metadata:
+      labels:
+        app: influxdb-operator
+    spec:
+      containers:
+      - name: operator
+        image: quay.io/influxdata/influxdb-operator:latest


### PR DESCRIPTION
## Summary
- add minimal Deployment for the InfluxDB operator
- document the new operator in the microk8s README

## Testing
- `helm lint microk8s/charts/openhab-stack` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aa03177588326a3b3f9a202b56884