### PR TITLE
Add Podman deployment configs for OpenHAB stack

### DIFF
--- a/podman/README.md
+++ b/podman/README.md
@@ -1,0 +1,22 @@
+# Podman Deployment
+
+Sample configuration for running OpenHAB, Keycloak, Postgres, pgAdmin, Nginx, and Cloudflare Tunnel with Podman and systemd quadlet units.
+
+## Usage
+
+1. Create network and volumes:
+   ```bash
+   ./create-resources.sh
+   ```
+2. Copy quadlet files in `quadlet/` to `/etc/containers/systemd/` (or the user equivalent) and run:
+   ```bash
+   systemctl daemon-reload
+   systemctl enable --now nginx.service keycloak.service postgres.service pgadmin.service
+   ```
+3. Install `cloudflared` via apt, place `cloudflared/config.yml` at `/etc/cloudflared/config.yml`, and start the tunnel:
+   ```bash
+   sudo systemctl enable --now cloudflared
+   ```
+4. Mount your Let's Encrypt certificates at `/etc/letsencrypt` on the host so they are available to the Nginx container.
+5. Update placeholders such as database passwords, tunnel ID, and Cloudflare token before starting the services.
+6. Import `keycloak/realm-export.json` into Keycloak to preconfigure clients and WebAuthn policy.

--- a/podman/cloudflared/config.yml
+++ b/podman/cloudflared/config.yml
@@ -1,0 +1,14 @@
+---
+tunnel: YOUR-TUNNEL-ID
+credentials-file: /etc/cloudflared/YOUR-TUNNEL-ID.json
+
+ingress:
+  - hostname: openhab.cjssolutions.com
+    service: https://nginx:443
+  - hostname: keycloak.cjssolutions.com
+    service: https://nginx:443
+  - hostname: pgadmin.cjssolutions.com
+    service: https://nginx:443
+  - hostname: postgres.cjssolutions.com
+    service: tcp://nginx:5432
+  - service: http_status:404

--- a/podman/create-resources.sh
+++ b/podman/create-resources.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NETWORK_NAME=internal-net
+VOLUMES=(pgdata keycloak-data nginx-config pgadmin-data)
+
+if ! podman network exists "$NETWORK_NAME"; then
+  podman network create "$NETWORK_NAME"
+fi
+
+for v in "${VOLUMES[@]}"; do
+  if ! podman volume inspect "$v" >/dev/null 2>&1; then
+    podman volume create "$v"
+  fi
+done

--- a/podman/keycloak/realm-export.json
+++ b/podman/keycloak/realm-export.json
@@ -1,0 +1,39 @@
+{
+  "realm": "home",
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "webAuthnPolicy": {
+    "rpEntityName": "CJSSolutions",
+    "rpId": "cjssolutions.com",
+    "signatureAlgorithms": ["ES256"],
+    "attestationConveyancePreference": "not specified",
+    "authenticatorAttachment": "not specified",
+    "requireResidentKey": "No",
+    "userVerificationRequirement": "required"
+  },
+  "clients": [
+    {
+      "clientId": "openhab",
+      "publicClient": true,
+      "redirectUris": [
+        "https://openhab.cjssolutions.com/*"
+      ]
+    },
+    {
+      "clientId": "pgadmin",
+      "publicClient": false,
+      "protocol": "openid-connect",
+      "redirectUris": [
+        "https://pgadmin.cjssolutions.com/*"
+      ]
+    },
+    {
+      "clientId": "cloudflared",
+      "publicClient": false,
+      "protocol": "openid-connect",
+      "serviceAccountsEnabled": true,
+      "clientAuthenticatorType": "client-secret"
+    }
+  ]
+}

--- a/podman/nginx/nginx.conf
+++ b/podman/nginx/nginx.conf
@@ -1,0 +1,82 @@
+user nginx;
+worker_processes auto;
+
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
+
+ events {
+    worker_connections 1024;
+ }
+
+ http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    server {
+        listen 80;
+        server_name _;
+        return 301 https://$host$request_uri;
+    }
+
+    server {
+        listen 443 ssl;
+        server_name openhab.cjssolutions.com;
+
+        ssl_certificate /etc/letsencrypt/live/cjssolutions.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/cjssolutions.com/privkey.pem;
+
+        location / {
+            proxy_pass http://host.containers.internal:8080;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+
+    server {
+        listen 443 ssl;
+        server_name keycloak.cjssolutions.com;
+
+        ssl_certificate /etc/letsencrypt/live/cjssolutions.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/cjssolutions.com/privkey.pem;
+
+        location / {
+            proxy_pass http://keycloak:8080;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+
+    server {
+        listen 443 ssl;
+        server_name pgadmin.cjssolutions.com;
+
+        ssl_certificate /etc/letsencrypt/live/cjssolutions.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/cjssolutions.com/privkey.pem;
+
+        location / {
+            proxy_pass http://pgadmin:80;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+ }
+
+ stream {
+    upstream postgres {
+        server postgres:5432;
+    }
+
+    server {
+        listen 5432;
+        proxy_pass postgres;
+    }
+ }

--- a/podman/quadlet/keycloak.container
+++ b/podman/quadlet/keycloak.container
@@ -1,0 +1,19 @@
+[Unit]
+Description=Keycloak container
+
+[Container]
+Image=quay.io/keycloak/keycloak:latest
+AutoUpdate=registry
+Network=internal-net
+Volume=keycloak-data:/opt/keycloak/data
+Environment=KC_PROXY=edge
+Environment=KC_HOSTNAME=keycloak.cjssolutions.com
+Environment=KC_HTTP_PORT=8080
+Environment=KC_DB=postgres
+Environment=KC_DB_URL=jdbc:postgresql://postgres:5432/keycloak
+Environment=KC_DB_USERNAME=keycloak
+Environment=KC_DB_PASSWORD=change_me
+Command=start --optimized
+
+[Install]
+WantedBy=multi-user.target

--- a/podman/quadlet/nginx.container
+++ b/podman/quadlet/nginx.container
@@ -1,0 +1,15 @@
+[Unit]
+Description=Nginx reverse proxy
+After=keycloak.service postgres.service pgadmin.service
+
+[Container]
+Image=nginx:alpine
+AutoUpdate=registry
+Network=internal-net
+PublishPort=80:80
+PublishPort=443:443
+Volume=nginx-config:/etc/nginx/conf.d:Z
+Volume=/etc/letsencrypt:/etc/letsencrypt:ro
+
+[Install]
+WantedBy=multi-user.target

--- a/podman/quadlet/pgadmin.container
+++ b/podman/quadlet/pgadmin.container
@@ -1,0 +1,13 @@
+[Unit]
+Description=pgAdmin management UI
+
+[Container]
+Image=dpage/pgadmin4:latest
+AutoUpdate=registry
+Network=internal-net
+Volume=pgadmin-data:/var/lib/pgadmin
+Environment=PGADMIN_DEFAULT_EMAIL=admin@cjssolutions.com
+Environment=PGADMIN_DEFAULT_PASSWORD=change_me
+
+[Install]
+WantedBy=multi-user.target

--- a/podman/quadlet/postgres.container
+++ b/podman/quadlet/postgres.container
@@ -1,0 +1,14 @@
+[Unit]
+Description=PostgreSQL database
+
+[Container]
+Image=postgres:16
+AutoUpdate=registry
+Network=internal-net
+Volume=pgdata:/var/lib/postgresql/data:Z
+Environment=POSTGRES_DB=keycloak
+Environment=POSTGRES_USER=keycloak
+Environment=POSTGRES_PASSWORD=change_me
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add quadlet units for Keycloak, Postgres, pgAdmin, and Nginx
- provide sample Nginx reverse proxy and Cloudflared ingress config
- include Keycloak realm export and helper script for network and volumes
- document using host-managed cloudflared on Ubuntu

## Testing
- `bash -n podman/create-resources.sh`
- `yamllint podman/cloudflared/config.yml`
- `jq . podman/keycloak/realm-export.json >/tmp/realm.json`


------
https://chatgpt.com/codex/tasks/task_e_68a1fc3e66788326a039624d0a11cb96