### PR TITLE
Enable TLS for admin components

### DIFF
--- a/podman/quadlet/keycloak.env
+++ b/podman/quadlet/keycloak.env
@@ -2,6 +2,6 @@ KC_PROXY=edge
 KC_HOSTNAME=keycloak.cjssolutions.com
 KC_HTTP_PORT=8080
 KC_DB=postgres
-KC_DB_URL=jdbc:postgresql://postgres:5432/keycloak?sslmode=verify-full&sslrootcert=/etc/letsencrypt/live/cjssolutions.com/fullchain.pem&sslcert=/etc/letsencrypt/live/cjssolutions.com/cert.pem&sslkey=/etc/letsencrypt/live/cjssolutions.com/privkey.pem
+KC_DB_URL=jdbc:postgresql://postgres.cjssolutions.com:5432/keycloak?sslmode=verify-full&sslrootcert=/etc/letsencrypt/live/cjssolutions.com/fullchain.pem&sslcert=/etc/letsencrypt/live/cjssolutions.com/cert.pem&sslkey=/etc/letsencrypt/live/cjssolutions.com/privkey.pem
 KC_DB_USERNAME=keycloak
 KC_DB_PASSWORD=change_me

--- a/podman/quadlet/pgadmin.env
+++ b/podman/quadlet/pgadmin.env
@@ -2,3 +2,8 @@ PGADMIN_DEFAULT_EMAIL=admin@cjssolutions.com
 PGADMIN_DEFAULT_PASSWORD=change_me
 PGADMIN_SERVER_JSON_FILE=/pgadmin4/servers.json
 PGADMIN_REPLACE_SERVERS_ON_STARTUP=True
+
+PGADMIN_ENABLE_TLS=True
+PGADMIN_LISTEN_PORT=443
+PGADMIN_CERT_FILE=/etc/letsencrypt/live/cjssolutions.com/fullchain.pem
+PGADMIN_KEY_FILE=/etc/letsencrypt/live/cjssolutions.com/privkey.pem


### PR DESCRIPTION
## Summary
- connect Keycloak to Postgres using Let's Encrypt certificate
- enable HTTPS for pgAdmin using Let's Encrypt cert and key

## Testing
- `bash -n podman/quadlet/keycloak.env podman/quadlet/pgadmin.env`


------
https://chatgpt.com/codex/tasks/task_e_68a20a93bda883268472e9ee58f41f80