### PR TITLE
Use mTLS certs for pgAdmin and Keycloak

### DIFF
--- a/podman/quadlet/keycloak.container
+++ b/podman/quadlet/keycloak.container
@@ -7,6 +7,7 @@ AutoUpdate=registry
 Network=internal-net
 Volume=keycloak-data:/opt/keycloak/data
 Volume=/etc/letsencrypt:/etc/letsencrypt:ro
+Volume=/etc/oh-expose/clients/keycloak:/etc/oh-expose/clients/keycloak:ro
 EnvironmentFile=%d/keycloak.env
 Command=start --optimized
 

--- a/podman/quadlet/keycloak.env
+++ b/podman/quadlet/keycloak.env
@@ -2,6 +2,6 @@ KC_PROXY=edge
 KC_HOSTNAME=keycloak.cjssolutions.com
 KC_HTTP_PORT=8080
 KC_DB=postgres
-KC_DB_URL=jdbc:postgresql://postgres.cjssolutions.com:5432/keycloak?sslmode=verify-full&sslrootcert=/etc/letsencrypt/live/cjssolutions.com/fullchain.pem&sslcert=/etc/letsencrypt/live/cjssolutions.com/cert.pem&sslkey=/etc/letsencrypt/live/cjssolutions.com/privkey.pem
+KC_DB_URL=jdbc:postgresql://postgres.cjssolutions.com:5432/keycloak?sslmode=verify-full&sslrootcert=/etc/letsencrypt/live/cjssolutions.com/fullchain.pem&sslcert=/etc/oh-expose/clients/keycloak/client.crt&sslkey=/etc/oh-expose/clients/keycloak/client.key
 KC_DB_USERNAME=keycloak
 KC_DB_PASSWORD=change_me

--- a/podman/quadlet/pgadmin-servers.json
+++ b/podman/quadlet/pgadmin-servers.json
@@ -10,8 +10,8 @@
       "ConnectionParameters": {
         "sslmode": "verify-full",
         "sslrootcert": "/etc/letsencrypt/live/cjssolutions.com/fullchain.pem",
-        "sslcert": "/etc/letsencrypt/live/cjssolutions.com/cert.pem",
-        "sslkey": "/etc/letsencrypt/live/cjssolutions.com/privkey.pem"
+        "sslcert": "/etc/oh-expose/clients/pg-admin/client.crt",
+        "sslkey": "/etc/oh-expose/clients/pg-admin/client.key"
       }
     }
   }

--- a/podman/quadlet/pgadmin.container
+++ b/podman/quadlet/pgadmin.container
@@ -7,6 +7,7 @@ AutoUpdate=registry
 Network=internal-net
 Volume=pgadmin-data:/var/lib/pgadmin
 Volume=/etc/letsencrypt:/etc/letsencrypt:ro
+Volume=/etc/oh-expose/clients/pg-admin:/etc/oh-expose/clients/pg-admin:ro
 Volume=%d/pgadmin-servers.json:/pgadmin4/servers.json:ro
 EnvironmentFile=%d/pgadmin.env
 


### PR DESCRIPTION
## Summary
- mount client certificate directories into pgAdmin and Keycloak containers
- configure pgAdmin and Keycloak to present their client certificates when connecting to Postgres

## Testing
- `yamllint podman/quadlet/pgadmin-servers.json`
- `shellcheck podman/create-resources.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a2205ac43083269618f23e0734b6b5