### PR TITLE
Enable PostgreSQL certificate authentication

### DIFF
--- a/podman/quadlet/pg_hba.conf
+++ b/podman/quadlet/pg_hba.conf
@@ -1,0 +1,2 @@
+hostssl all all 0.0.0.0/0 cert clientcert=1
+hostssl all all ::/0 cert clientcert=1

--- a/podman/quadlet/postgres.container
+++ b/podman/quadlet/postgres.container
@@ -6,7 +6,11 @@ Image=postgres:16
 AutoUpdate=registry
 Network=internal-net
 Volume=pgdata:/var/lib/postgresql/data:Z
+Volume=/etc/letsencrypt:/etc/letsencrypt:ro
+Volume=%d/postgresql.conf:/etc/postgresql/postgresql.conf:ro
+Volume=%d/pg_hba.conf:/etc/postgresql/pg_hba.conf:ro
 EnvironmentFile=%d/postgres.env
+Command=postgres -c config_file=/etc/postgresql/postgresql.conf
 
 [Install]
 WantedBy=multi-user.target

--- a/podman/quadlet/postgres.env
+++ b/podman/quadlet/postgres.env
@@ -1,3 +1,2 @@
 POSTGRES_DB=keycloak
 POSTGRES_USER=keycloak
-POSTGRES_PASSWORD=change_me

--- a/podman/quadlet/postgresql.conf
+++ b/podman/quadlet/postgresql.conf
@@ -1,0 +1,4 @@
+ssl = on
+ssl_cert_file = '/etc/letsencrypt/live/postgres/fullchain.pem'
+ssl_key_file = '/etc/letsencrypt/live/postgres/privkey.pem'
+hba_file = '/etc/postgresql/pg_hba.conf'


### PR DESCRIPTION
## Summary
- mount Let's Encrypt certificates and SSL configs in postgres container
- enable SSL with certificate auth in PostgreSQL
- remove password from Postgres env once cert auth is used

## Testing
- `podman ps` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a21b7df42c8326a2c4e1f53bab4e61