### PR TITLE
Remove Keycloak DB password

### DIFF
--- a/podman/quadlet/keycloak.env
+++ b/podman/quadlet/keycloak.env
@@ -4,4 +4,3 @@ KC_HTTP_PORT=8080
 KC_DB=postgres
 KC_DB_URL=jdbc:postgresql://postgres.cjssolutions.com:5432/keycloak?sslmode=verify-full&sslrootcert=/etc/letsencrypt/live/cjssolutions.com/fullchain.pem&sslcert=/etc/letsencrypt/live/cjssolutions.com/cert.pem&sslkey=/etc/letsencrypt/live/cjssolutions.com/privkey.pem
 KC_DB_USERNAME=keycloak
-KC_DB_PASSWORD=change_me


### PR DESCRIPTION
## Summary
- rely on certificate-only database credentials by removing `KC_DB_PASSWORD` from Keycloak environment

## Testing
- `podman run --rm -v /tmp/letsencrypt:/etc/letsencrypt:ro --env-file podman/quadlet/keycloak.env quay.io/keycloak/keycloak:latest start --optimized` *(fails: netavark setns Operation not permitted)*

------
https://chatgpt.com/codex/tasks/task_e_68a21b6cbcf0832692a475063a0e9fcd