### PR TITLE
Expose Keycloak through dedicated Cloudflare tunnel

### DIFF
--- a/podman/cloudflared/config.yml
+++ b/podman/cloudflared/config.yml
@@ -1,14 +1,8 @@
 ---
-tunnel: YOUR-TUNNEL-ID
-credentials-file: /etc/cloudflared/YOUR-TUNNEL-ID.json
+tunnel: YOUR-KEYCLOAK-TUNNEL-ID
+credentials-file: /etc/cloudflared/YOUR-KEYCLOAK-TUNNEL-ID.json
 
 ingress:
-  - hostname: openhab.cjssolutions.com
-    service: https://nginx:443
   - hostname: keycloak.cjssolutions.com
-    service: https://nginx:443
-  - hostname: pgadmin.cjssolutions.com
-    service: https://nginx:443
-  - hostname: postgres.cjssolutions.com
-    service: tcp://nginx:5432
+    service: http://keycloak:8080
   - service: http_status:404


### PR DESCRIPTION
## Summary
- update the sample Cloudflare tunnel configuration to route keycloak traffic directly to the container
- document how to run cloudflared for keycloak without nginx and clarify optional services
- add commands for reviewing cloudflared configuration and re-enabling the service when disabled

## Testing
- yamllint podman/cloudflared/config.yml
- npx markdownlint-cli@latest podman/README.md

------
https://chatgpt.com/codex/tasks/task_e_68d54240b640832687545770eb501b19